### PR TITLE
Remove pagination, implement infinite scroll

### DIFF
--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -6,7 +6,7 @@ import * as $_404 from "./routes/_404.tsx";
 import * as $_app from "./routes/_app.tsx";
 import * as $api_data from "./routes/api/data.ts";
 import * as $index from "./routes/index.tsx";
-
+import * as $EventList from "./islands/EventList.tsx";
 import type { Manifest } from "$fresh/server.ts";
 
 const manifest = {
@@ -16,7 +16,9 @@ const manifest = {
     "./routes/api/data.ts": $api_data,
     "./routes/index.tsx": $index,
   },
-  islands: {},
+  islands: {
+    "./islands/EventList.tsx": $EventList,
+  },
   baseUrl: import.meta.url,
 } satisfies Manifest;
 

--- a/islands/EventList.tsx
+++ b/islands/EventList.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import { Event } from "../utils/types.ts";
+
+export default function EventList() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+
+  async function loadEvents(page: number) {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    const res = await fetch(`/api/events?page=${page}&perPage=10`);
+    const data = await res.json();
+    setEvents((prev) => [...prev, ...data.events]);
+    setHasMore(page < data.totalPages);
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    loadEvents(page);
+  }, [page]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        setPage((prev) => prev + 1);
+      }
+    });
+
+    const el = loaderRef.current;
+    if (el) observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [loaderRef.current, hasMore]);
+
+  return (
+    <>
+      <ul class="event-list">
+        {events.map((event) => (
+          <li class="event-card" key={event.url}>
+            <div class="column-left">
+              {event.image !== "Unknown image" && <img src={event.image} />}
+            </div>
+            <div class="column-middle">
+              {event.tags?.length > 0 && (
+                <div class="tags">
+                  {event.tags.map((tag) => (
+                    <span class="tag" key={tag}>{tag}</span>
+                  ))}
+                </div>
+              )}
+              <h2>{event.title}</h2>
+              <p class="description">{event.description}</p>
+              <p class="info">Location: {event.location}</p>
+              <p class="info">Date/Time: {event.datetime}</p>
+            </div>
+            <div class="column-right">
+              <a
+                href={`https://ocparks.com/${event.url}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                External Link
+              </a>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {loading && <p>Loading more events...</p>}
+      <div ref={loaderRef} style={{ height: "1px" }} />
+    </>
+  );
+}

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -1,113 +1,14 @@
-/// <reference lib="deno.unstable" />
-import { Handlers, PageProps } from "$fresh/server.ts";
-import { Event } from "../utils/types.ts";
 import Navbar from "../components/Navbar.tsx";
 import Footer from "../components/Footer.tsx";
-import { fetchEvents } from "../utils/events.ts";
+import EventList from "../islands/EventList.tsx";
 
-type Data = {
-  events: Event[];
-  page: number;
-  totalPages: number;
-};
-
-/**
- * Fetches events from the KV store and paginates them.
- * @param req - The request object.
- * @param ctx - The context object.
- * @return A response containing the paginated events.
- */
-export const handler: Handlers<Data> = {
-  async GET(req, ctx) {
-    const url = new URL(req.url);
-    const page = parseInt(url.searchParams.get("page") || "1");
-    const perPage = 10;
-
-    const kv = await Deno.openKv();
-
-    const firstEntry = await kv.list({ prefix: ["events", "item"] }).next();
-    if (firstEntry.done) {
-      console.log("KV empty. Fetching and storing events...");
-      const events = await fetchEvents();
-
-      for (const [index, event] of events.entries()) {
-        await kv.set(["events", "item", index], event);
-      }
-
-      console.log(`Stored ${events.length} events.`);
-    }
-
-    const allEvents: Event[] = [];
-    for await (const entry of kv.list<Event>({ prefix: ["events", "item"] })) {
-      allEvents.push(entry.value);
-    }
-
-    allEvents.sort((a, b) =>
-      new Date(a.datetime).getTime() - new Date(b.datetime).getTime()
-    );
-
-    const totalPages = Math.ceil(allEvents.length / perPage);
-    const paginatedEvents = allEvents.slice(
-      (page - 1) * perPage,
-      page * perPage,
-    );
-
-    return ctx.render({
-      events: paginatedEvents,
-      page,
-      totalPages,
-    });
-  },
-};
-
-export default function Home({ data }: PageProps<Data>) {
-  const { events, page, totalPages } = data;
-
+export default function Home() {
   return (
     <div class="container">
       <Navbar />
       <main class="content">
         <h1>Discover and Explore OC Parks Events with Smart Filtering</h1>
-        <ul class="event-list">
-          {events.map((event) => (
-            <li class="event-card" key={event.url}>
-              <div class="column-left">
-                {event.image !== "Unknown image" && <img src={event.image} />}
-              </div>
-
-              <div class="column-middle">
-                {event.tags && event.tags.length > 0 && (
-                  <div class="tags">
-                    {event.tags.map((tag) => (
-                      <span class="tag" key={tag}>{tag}</span>
-                    ))}
-                  </div>
-                )}
-                <h2>{event.title}</h2>
-                <p class="description">{event.description}</p>
-                <p class="info">Location {event.location}</p>
-                <p class="info">Date/Time {event.datetime}</p>
-              </div>
-
-              <div class="column-right">
-                {
-                  <a
-                    href={`https://ocparks.com/${event.url}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    External Link
-                  </a>
-                }
-              </div>
-            </li>
-          ))}
-        </ul>
-
-        <div class="pagination">
-          {page > 1 ? <a href={`?page=${page - 1}`}>← Previous</a> : <div />}
-          {page < totalPages && <a href={`?page=${page + 1}`}>Next →</a>}
-        </div>
+        <EventList />
       </main>
       <Footer />
     </div>

--- a/utils/events.ts
+++ b/utils/events.ts
@@ -1,3 +1,4 @@
+/// <reference lib="deno.unstable" />
 import { DOMParser } from "jsr:@b-fuze/deno-dom";
 import { Event } from "./types.ts";
 import { fetchEventDetails } from "./links.ts";


### PR DESCRIPTION
Pagination was too hard to implement because there were too many pages and the option to see the current page, the previous/next/last page was difficult to create so I switched to an endless scroll instead.

Fix #6.